### PR TITLE
Fix `llm4ad.base.evaluate.SecureEvaluator`

### DIFF
--- a/llm4ad/base/evaluate.py
+++ b/llm4ad/base/evaluate.py
@@ -235,7 +235,9 @@ class SecureEvaluator:
                 # return evaluate result and evaluate time
                 return result, time.time() - evaluate_start
             else:
-                return self._evaluate(program_str, function_name)
+                start = time.time()
+                score = self._evaluate(program_str, function_name)
+                return score, time.time() - start
         except Exception as e:
             if self._debug_mode:
                 print(e)


### PR DESCRIPTION
If the SecureEvaluator is initialized with `safe_evaluate=False`, the `self.evaluate_program_record_time()` function will fail to return the execution time. 

And the bug is fixed by adding the execution time record.

Only three lines changed in `llm4ad/base/evaluate.py` file.